### PR TITLE
Bump version to 1.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-license",
-  "version": "1.2.6",
+  "version": "1.2.9",
   "description": "Export and display NPM/Bower dependencies",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We're planning to use your fork in the Ember app at my company but I noticed it's not pulling the correct version. Although there were two releases with version bumps to `1.2.7` and `1.2.8`, it still seems to be pulling the old `1.2.6` release since this was never updated in the package.json. Bumping this would then need a v1.2.9 release or tag to be created.

This is what I see in my yarn.lock file:

```
"ember-cli-license@git+ssh://git@github.com/smartbear/ember-cli-license.git#v1.2.8":
  version "1.2.6"
  resolved "git+ssh://git@github.com/smartbear/ember-cli-license.git#74db1b6cd791f063c5c8da9f8c480996bca22f56"
  dependencies:
    bower-json "^0.8.4"
    ember-cli-babel "^6.11.0"
    ember-cli-htmlbars "^1.0.10"
    license-checker "^19.0.0"
    mkdirp "^0.5.1"
    node-dir "^0.1.16"
    rsvp "^3.3.3"
    underscore "^1.8.3"
```